### PR TITLE
Make a NB -connection

### DIFF
--- a/main.ino
+++ b/main.ino
@@ -91,6 +91,11 @@ void setup() {
   MODEM.waitForResponse(4000);
   Serial.println("done.");
 
+  // Check if connected and if not, reconnect
+  if (nbAccess.status() != NB_READY || gprsAccess.status() != GPRS_READY) {
+    connectNB();
+  }
+
   // Initialize CoAP client
   coap.start();
 


### PR DESCRIPTION
The call to coap.start() depends on a valid  -connection

bool Coap::start() {
    this->start(COAP_DEFAULT_PORT);
    return true;
}

bool Coap::start(int port) {
    this->_udp->begin(port);  //  ... if, not, this request will faile.
    return true;
}